### PR TITLE
Minor bugfixes to reflect ATOCA changes

### DIFF
--- a/exotedrf/stage3.py
+++ b/exotedrf/stage3.py
@@ -313,7 +313,6 @@ def specprofilestep(datafiles, empirical=True, output_dir='./'):
             cube = data.data
         else:
             cube = np.concatenate([cube, data.data])
-        data.close()
     deepstack = utils.make_deepstack(cube)
 
     # Initialize and run the APPLESOSS module with the median stack.
@@ -379,7 +378,7 @@ def atoca_extract_soss(datafiles, specprofile, output_dir='./', save_results=Tru
             step = calwebb_spec2.extract_1d_step.Extract1dStep()
             try:
                 res = step.call(segment, output_dir=output_dir, save_results=save_results,
-                                soss_transform=[0, 0, 0], subtract_background=False,
+                                subtract_background=False,
                                 soss_bad_pix='model', soss_width=extract_width,
                                 soss_modelname=soss_modelname, override_specprofile=specprofile,
                                 soss_estimate=soss_estimate)


### PR DESCRIPTION
Currently attempting to use ATOCA for spectral extraction gives two errors. (1) Line 316 of stage3.py has a stray data.close() as it is calling .close() on an ndarray, (2) calwebb syntax no longer recognises soss_transform in atoca_extract_soss and can be removed. 

Removal of these two areas made atoca run fine afterwards for me. 